### PR TITLE
Move embarkjs

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,7 @@
 {
   "compact": false,
   "presets": [
-    ["@babel/preset-env", {"targets": {"node": "8.11.3"}}]
+    ["@babel/env", {"targets": {"node": "8.11.3"}}]
   ],
   "plugins": [
     "@babel/plugin-transform-runtime"

--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,9 @@
+{
+  "compact": false,
+  "presets": [
+    ["@babel/preset-env", {"targets": {"node": "8.11.3"}}]
+  ],
+  "plugins": [
+    "@babel/plugin-transform-runtime"
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,13 @@
 dist
 node_modules
+package
 
 .idea
 .vscode
 .eslintrc.json
 
 embark.min.js
+embarkjs-*.tgz
 TODO
 NOTES
 npm-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+dist
+node_modules
+
+.idea
+.vscode
+.eslintrc.json
+
+embark.min.js
+TODO
+NOTES
+npm-debug.log

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+package-lock = false
+save-exact = true

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 iuri matias
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # EmbarkJS
+
+A JavaScript library for easily interacting with web3 technologies.
+
+This library is part of the [Embark](https://github.com/embark-framework/embark) framework.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>EmbarkJS &mdash; standalone</title>
+        <script src="embark.min.js"></script>
+    </head>
+    <body></body>
+</html>

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "npm run clean && npm run build-babel && npm run build-webpack",
     "build-babel": "babel --ignore 'src/browser.js' --out-dir dist src",
     "build-webpack": "npm run webpack",
-    "clean": "rimraf dist embark.min.js",
+    "clean": "rimraf dist embark.min.js embarkjs-*.tgz",
     "prepack": "npm run build",
     "server": "http-server",
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,15 @@
   },
   "author": "Iuri Matias <iuri.matias@gmail.com>",
   "license": "MIT",
+  "keywords": [
+    "ethereum",
+    "dapps",
+    "ipfs",
+    "solidity",
+    "solc",
+    "blockchain",
+    "serverless"
+  ],
   "bugs": {
     "url": "https://github.com/embark-framework/EmbarkJS/issues"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "build": "npm run clean && npm run build-babel && npm run build-webpack",
-    "build-babel": "babel --out-dir dist src",
+    "build-babel": "babel --ignore 'src/browser.js' --out-dir dist src",
     "build-webpack": "npm run webpack",
     "clean": "rimraf dist embark.min.js",
     "prepack": "npm run build",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build-babel": "babel --out-dir dist src",
     "build-webpack": "npm run webpack",
     "clean": "rimraf dist embark.min.js",
+    "prepack": "npm run build",
     "server": "http-server",
     "test": "echo \"Error: no test specified\" && exit 1",
     "webpack": "webpack"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "browser": "./src/browser.js",
   "files": [
     "dist",
-    "embark.min.js"
+    "embark.min.js",
+    "src"
   ],
   "scripts": {
     "build": "npm run clean && npm run build-babel && npm run build-webpack",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "npm run clean && npm run build-babel && npm run build-webpack",
     "build-babel": "babel --ignore 'src/browser.js' --out-dir dist src",
     "build-webpack": "npm run webpack",
-    "clean": "rimraf dist embark.min.js embarkjs-*.tgz",
+    "clean": "rimraf dist embark.min.js embarkjs-*.tgz package",
     "prepack": "npm run build",
     "server": "http-server",
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "main": "./dist/index.js",
-  "browser": "./dist/browser.js",
+  "browser": "./src/browser.js",
   "files": [
     "dist",
     "embark.min.js"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "embarkjs",
+  "version": "0.1.0",
+  "description": "",
+  "main": "./dist/index.js",
+  "browser": "./dist/browser.js",
+  "files": [
+    "dist",
+    "embark.min.js"
+  ],
+  "scripts": {
+    "build": "npm run clean && npm run build-babel && npm run build-webpack",
+    "build-babel": "babel --out-dir dist src",
+    "build-webpack": "npm run webpack",
+    "clean": "rimraf dist embark.min.js",
+    "server": "http-server",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "webpack": "webpack"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embark-framework/EmbarkJS.git"
+  },
+  "author": "Iuri Matias <iuri.matias@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/embark-framework/EmbarkJS/issues"
+  },
+  "homepage": "https://github.com/embark-framework/EmbarkJS#readme",
+  "dependencies": {
+    "@babel/runtime": "7.0.0-beta.52"
+  },
+  "devDependencies": {
+    "@babel/cli": "7.0.0-beta.52",
+    "@babel/core": "7.0.0-beta.52",
+    "@babel/plugin-transform-modules-commonjs": "7.0.0-beta.52",
+    "@babel/plugin-transform-runtime": "7.0.0-beta.52",
+    "@babel/preset-env": "7.0.0-beta.52",
+    "ajv": "6.5.2",
+    "babel-loader": "8.0.0-beta.4",
+    "http-server": "0.11.1",
+    "rimraf": "2.6.2",
+    "webpack": "4.15.1",
+    "webpack-cli": "3.0.8"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   "devDependencies": {
     "@babel/cli": "7.0.0-beta.52",
     "@babel/core": "7.0.0-beta.52",
-    "@babel/plugin-transform-modules-commonjs": "7.0.0-beta.52",
     "@babel/plugin-transform-runtime": "7.0.0-beta.52",
     "@babel/preset-env": "7.0.0-beta.52",
     "ajv": "6.5.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "embarkjs",
   "version": "0.1.0",
-  "description": "",
+  "description": "JavaScript library for easily interacting with web3 technologies",
   "main": "./dist/index.js",
   "browser": "./src/browser.js",
   "files": [

--- a/src/browser.js
+++ b/src/browser.js
@@ -1,0 +1,14 @@
+import _EmbarkJS from './embark';
+
+var EmbarkJS = Object.assign({}, _EmbarkJS);
+
+EmbarkJS.checkWeb3 = function () {
+    _EmbarkJS.checkWeb3.call(this);
+    if (!this.web3 && typeof (web3) !== 'undefined') {
+        this.web3 = web3;
+    } else  if (!this.web3) {
+        this.web3 = window.web3;
+    }
+};
+
+export default EmbarkJS;

--- a/src/embark.js
+++ b/src/embark.js
@@ -15,6 +15,8 @@ EmbarkJS.isNewWeb3 = function (web3Obj) {
   return parseInt(_web3.version.api.split('.')[0], 10) >= 1;
 };
 
+EmbarkJS.checkWeb3 = function () {};
+
 EmbarkJS.Contract = function (options) {
   var self = this;
   var i, abiElement;
@@ -24,13 +26,16 @@ EmbarkJS.Contract = function (options) {
   this.address = options.address;
   this.gas = options.gas;
   this.code = '0x' + options.code;
+
   //this.web3 = options.web3 || web3;
   this.web3 = options.web3;
-  if (!this.web3 && typeof (web3) !== 'undefined') {
-    this.web3 = web3;
-  } else if (!this.web3) {
-    this.web3 = window.web3;
-  }
+
+  //if (!this.web3 && typeof (web3) !== 'undefined') {
+  //  this.web3 = web3;
+  //} else if (!this.web3) {
+  //  this.web3 = window.web3;
+  //}
+  EmbarkJS.checkWeb3.call(this);
 
   if (EmbarkJS.isNewWeb3(this.web3)) {
     ContractClass = new this.web3.eth.Contract(this.abi, this.address);

--- a/src/embark.js
+++ b/src/embark.js
@@ -1,0 +1,399 @@
+var EmbarkJS = {
+  onReady: function (cb) {
+    if (typeof (__embarkContext) === 'undefined') {
+      return cb();
+    }
+    return __embarkContext.execWhenReady(cb);
+  }
+};
+
+EmbarkJS.isNewWeb3 = function (web3Obj) {
+  var _web3 = web3Obj || (new Web3());
+  if (typeof(_web3.version) === "string") {
+    return true;
+  }
+  return parseInt(_web3.version.api.split('.')[0], 10) >= 1;
+};
+
+EmbarkJS.Contract = function (options) {
+  var self = this;
+  var i, abiElement;
+  var ContractClass;
+
+  this.abi = options.abi;
+  this.address = options.address;
+  this.gas = options.gas;
+  this.code = '0x' + options.code;
+  //this.web3 = options.web3 || web3;
+  this.web3 = options.web3;
+  if (!this.web3 && typeof (web3) !== 'undefined') {
+    this.web3 = web3;
+  } else if (!this.web3) {
+    this.web3 = window.web3;
+  }
+
+  if (EmbarkJS.isNewWeb3(this.web3)) {
+    ContractClass = new this.web3.eth.Contract(this.abi, this.address);
+    ContractClass.setProvider(this.web3.currentProvider);
+    ContractClass.options.data = this.code;
+    ContractClass.options.from = this.from || this.web3.eth.defaultAccount;
+    ContractClass.abi = ContractClass.options.abi;
+    ContractClass.address = this.address;
+    ContractClass.gas = this.gas;
+
+    let originalMethods = Object.keys(ContractClass);
+
+    ContractClass._jsonInterface.forEach((abi) => {
+      if (originalMethods.indexOf(abi.name) >= 0) {
+        console.log(abi.name + " is a reserved word and cannot be used as a contract method, property or event");
+        return;
+      }
+
+      if (!abi.inputs) {
+        return;
+      }
+
+      let numExpectedInputs = abi.inputs.length;
+
+      if (abi.type === 'function' && abi.constant) {
+        ContractClass[abi.name] = function () {
+          let options = {}, cb = null, args = Array.from(arguments || []).slice(0, numExpectedInputs);
+          if (typeof (arguments[numExpectedInputs]) === 'function') {
+            cb = arguments[numExpectedInputs];
+          } else if (typeof (arguments[numExpectedInputs]) === 'object') {
+            options = arguments[numExpectedInputs];
+            cb = arguments[numExpectedInputs + 1];
+          }
+
+          let ref = ContractClass.methods[abi.name];
+          let call = ref.apply(ref, ...arguments).call;
+          return call.apply(call, []);
+        };
+      } else if (abi.type === 'function') {
+        ContractClass[abi.name] = function () {
+          let options = {}, cb = null, args = Array.from(arguments || []).slice(0, numExpectedInputs);
+          if (typeof (arguments[numExpectedInputs]) === 'function') {
+            cb = arguments[numExpectedInputs];
+          } else if (typeof (arguments[numExpectedInputs]) === 'object') {
+            options = arguments[numExpectedInputs];
+            cb = arguments[numExpectedInputs + 1];
+          }
+
+          let ref = ContractClass.methods[abi.name];
+          let send = ref.apply(ref, args).send;
+          return send.apply(send, [options, cb]);
+        };
+      } else if (abi.type === 'event') {
+        ContractClass[abi.name] = function (options, cb) {
+          let ref = ContractClass.events[abi.name];
+          return ref.apply(ref, [options, cb]);
+        };
+      }
+    });
+
+    return ContractClass;
+  } else {
+    ContractClass = this.web3.eth.contract(this.abi);
+
+    this.eventList = [];
+
+    if (this.abi) {
+      for (i = 0; i < this.abi.length; i++) {
+        abiElement = this.abi[i];
+        if (abiElement.type === 'event') {
+          this.eventList.push(abiElement.name);
+        }
+      }
+    }
+
+    var messageEvents = function () {
+      this.cb = function () {
+      };
+    };
+
+    messageEvents.prototype.then = function (cb) {
+      this.cb = cb;
+    };
+
+    messageEvents.prototype.error = function (err) {
+      return err;
+    };
+
+    this._originalContractObject = ContractClass.at(this.address);
+    this._methods = Object.getOwnPropertyNames(this._originalContractObject).filter(function (p) {
+      // TODO: check for forbidden properties
+      if (self.eventList.indexOf(p) >= 0) {
+
+        self[p] = function () {
+          var promise = new messageEvents();
+          var args = Array.prototype.slice.call(arguments);
+          args.push(function (err, result) {
+            if (err) {
+              promise.error(err);
+            } else {
+              promise.cb(result);
+            }
+          });
+
+          self._originalContractObject[p].apply(self._originalContractObject[p], args);
+          return promise;
+        };
+        return true;
+      } else if (typeof self._originalContractObject[p] === 'function') {
+        self[p] = function (_args) {
+          var args = Array.prototype.slice.call(arguments);
+          var fn = self._originalContractObject[p];
+          var props = self.abi.find((x) => x.name == p);
+
+          var promise = new Promise(function (resolve, reject) {
+            args.push(function (err, transaction) {
+              promise.tx = transaction;
+              if (err) {
+                return reject(err);
+              }
+
+              var getConfirmation = function () {
+                self.web3.eth.getTransactionReceipt(transaction, function (err, receipt) {
+                  if (err) {
+                    return reject(err);
+                  }
+
+                  if (receipt !== null) {
+                    return resolve(receipt);
+                  }
+
+                  setTimeout(getConfirmation, 1000);
+                });
+              };
+
+              if (typeof transaction !== "string" || props.constant) {
+                resolve(transaction);
+              } else {
+                getConfirmation();
+              }
+            });
+
+            fn.apply(fn, args);
+          });
+
+          return promise;
+        };
+        return true;
+      }
+      return false;
+    });
+  }
+};
+
+EmbarkJS.Contract.prototype.deploy = function (args, _options) {
+  var self = this;
+  var contractParams;
+  var options = _options || {};
+
+  contractParams = args || [];
+
+  contractParams.push({
+    from: this.web3.eth.accounts[0],
+    data: this.code,
+    gas: options.gas || 800000
+  });
+
+  var contractObject = this.web3.eth.contract(this.abi);
+
+  var promise = new Promise(function (resolve, reject) {
+    contractParams.push(function (err, transaction) {
+      if (err) {
+        reject(err);
+      } else if (transaction.address !== undefined) {
+        resolve(new EmbarkJS.Contract({
+          abi: self.abi,
+          code: self.code,
+          address: transaction.address
+        }));
+      }
+    });
+
+    // returns promise
+    // deploys contract
+    // wraps it around EmbarkJS.Contract
+    contractObject["new"].apply(contractObject, contractParams);
+  });
+
+
+  return promise;
+};
+
+EmbarkJS.Contract.prototype.new = EmbarkJS.Contract.prototype.deploy;
+
+EmbarkJS.Contract.prototype.at = function (address) {
+  return new EmbarkJS.Contract({abi: this.abi, code: this.code, address: address});
+};
+
+EmbarkJS.Contract.prototype.send = function (value, unit, _options) {
+  var options, wei;
+  if (typeof unit === 'object') {
+    options = unit;
+    wei = value;
+  } else {
+    options = _options || {};
+    wei = this.web3.toWei(value, unit);
+  }
+
+  options.to = this.address;
+  options.value = wei;
+
+  this.web3.eth.sendTransaction(options);
+};
+
+EmbarkJS.Storage = {};
+
+EmbarkJS.Storage.Providers = {};
+
+EmbarkJS.Storage.saveText = function (text) {
+  if (!this.currentStorage) {
+    throw new Error('Storage provider not set; e.g EmbarkJS.Storage.setProvider("ipfs")');
+  }
+  return this.currentStorage.saveText(text);
+};
+
+EmbarkJS.Storage.get = function (hash) {
+  if (!this.currentStorage) {
+    throw new Error('Storage provider not set; e.g EmbarkJS.Storage.setProvider("ipfs")');
+  }
+  return this.currentStorage.get(hash);
+};
+
+EmbarkJS.Storage.uploadFile = function (inputSelector) {
+  if (!this.currentStorage) {
+    throw new Error('Storage provider not set; e.g EmbarkJS.Storage.setProvider("ipfs")');
+  }
+  return this.currentStorage.uploadFile(inputSelector);
+};
+
+EmbarkJS.Storage.getUrl = function (hash) {
+  if (!this.currentStorage) {
+    throw new Error('Storage provider not set; e.g EmbarkJS.Storage.setProvider("ipfs")');
+  }
+  return this.currentStorage.getUrl(hash);
+};
+
+EmbarkJS.Storage.registerProvider = function (providerName, obj) {
+  EmbarkJS.Storage.Providers[providerName] = obj;
+};
+
+EmbarkJS.Storage.setProvider = function (provider, options) {
+  let providerObj = this.Providers[provider];
+
+  if (!providerObj) {
+    throw new Error('Unknown storage provider');
+  }
+
+  this.currentStorage = providerObj;
+
+  return providerObj.setProvider(options);
+};
+
+EmbarkJS.Storage.isAvailable = function () {
+  if (!this.currentStorage) {
+    throw new Error('Storage provider not set; e.g EmbarkJS.Storage.setProvider("ipfs")');
+  }
+  return this.currentStorage.isAvailable();
+};
+
+EmbarkJS.Messages = {};
+
+EmbarkJS.Messages.Providers = {};
+
+EmbarkJS.Messages.registerProvider = function (providerName, obj) {
+  EmbarkJS.Messages.Providers[providerName] = obj;
+};
+
+EmbarkJS.Messages.setProvider = function (provider, options) {
+  let providerObj = this.Providers[provider];
+
+  if (!providerObj) {
+    throw new Error('Unknown messages provider');
+  }
+
+  this.currentMessages = providerObj;
+
+  return providerObj.setProvider(options);
+};
+
+EmbarkJS.Messages.isAvailable = function () {
+  return this.currentMessages.isAvailable();
+};
+
+EmbarkJS.Messages.sendMessage = function (options) {
+  if (!this.currentMessages) {
+    throw new Error('Messages provider not set; e.g EmbarkJS.Messages.setProvider("whisper")');
+  }
+  return this.currentMessages.sendMessage(options);
+};
+
+EmbarkJS.Messages.listenTo = function (options, callback) {
+  if (!this.currentMessages) {
+    throw new Error('Messages provider not set; e.g EmbarkJS.Messages.setProvider("whisper")');
+  }
+  return this.currentMessages.listenTo(options, callback);
+};
+
+EmbarkJS.Names = {};
+
+EmbarkJS.Names.Providers = {};
+
+EmbarkJS.Names.registerProvider = function (providerName, obj) {
+  EmbarkJS.Names.Providers[providerName] = obj;
+};
+
+EmbarkJS.Names.setProvider = function (provider, options) {
+  let providerObj = this.Providers[provider];
+
+  if (!providerObj) {
+    throw new Error('Unknown name system provider');
+  }
+
+  this.currentNameSystems = providerObj;
+
+  return providerObj.setProvider(options);
+};
+
+// resolve resolves a name into an identifier of some kind
+EmbarkJS.Names.resolve = function (name) {
+  if (!this.currentNameSystems) {
+    throw new Error('Name system provider not set; e.g EmbarkJS.Names.setProvider("ens")');
+  }
+  return this.currentNameSystems.resolve(name);
+};
+
+// the reverse of resolve, resolves using an identifier to get to a name
+EmbarkJS.Names.lookup = function (identifier) {
+  if (!this.currentNameSystems) {
+    throw new Error('Name system provider not set; e.g EmbarkJS.Names.setProvider("ens")');
+  }
+  return this.currentNameSystems.lookup(identifier);
+};
+
+// To Implement
+
+
+// register a name
+EmbarkJS.Names.register = function(name, options) {
+  if (!this.currentNameSystems) {
+    throw new Error('Name system provider not set; e.g EmbarkJS.Names.setProvider("ens")');
+  }
+  return this.currentNameSystems.register(name, options);
+}
+
+EmbarkJS.Utils = {
+  fromAscii: function (str) {
+    var _web3 = new Web3();
+    return _web3.utils ? _web3.utils.fromAscii(str) : _web3.fromAscii(str);
+  },
+  toAscii: function (str) {
+    var _web3 = new Web3();
+    return _web3.utils.toAscii(str);
+  }
+};
+
+export default EmbarkJS;

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./embark').default;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ const browser = {
                 use: {
                     loader: 'babel-loader',
                     options: {
+                        babelrc: false,
                         presets: [
                             ['@babel/env']
                         ]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 const browser = {
-    entry: path.resolve(__dirname, 'dist') + '/browser.js',
+    entry: path.resolve(__dirname, 'src') + '/browser.js',
     mode: 'production',
     module: {
         rules: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,38 @@
+const path = require('path');
+
+const browser = {
+    entry: path.resolve(__dirname, 'dist') + '/browser.js',
+    mode: 'production',
+    module: {
+        rules: [
+            {
+                test: /\.js$/,
+                exclude: /(node_modules|bower_components)/,
+                use: {
+                    loader: 'babel-loader',
+                    options: {
+                        presets: [
+                            ['@babel/env']
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    // optimization: {
+    //     minimize: false
+    // },
+    output: {
+        filename: 'embark.min.js',
+        library: 'EmbarkJS',
+        libraryTarget: 'umd',
+        libraryExport: 'default',
+        path: __dirname,
+        umdNamedDefine: true,
+    },
+    target: 'web'
+};
+
+module.exports = [
+    browser
+];


### PR DESCRIPTION
Initial work to extract `embark.js` from Embark and have it be a separate npm package.

`package.json` needs a bit more work prior to publishing to the npm registry; README needs to be filled in, and we may want to think about packaging `embark.min.js` in GitHub releases.

-------

If you clone this branch and run `npm install . && npm build`, scripts in `src/` will be run through babel and output in `dist/`. Also, the browser entrypoint will be run through webpack and an `embark.min.js` file will be output in the project root.

# Rationale

`src/embark.js` is written as an ES module, e.g. making use of `export default` and could possibly make use of `import` or other JS lang features that babel supports via polyfill.

In order to have that script be a proper node module, consumable via `require()` by other modules, such as Embark itself, `/src/embark.js` is run through babel. It is not necessary that it be run through webpack, only that it be a valid commonjs module. A `dist/index.js` entrypoint is provided for node (see `"main"` in `package.json`) to get around the `exports.default` issue when babel compiles ES modules to commonjs.

A different entrypoint, `dist/browser.js` is provided (see `"browser"` in `package.json`), which will be respected by downstream webpack pipelines (e.g. Embark's pipeline) and other pipeline-tools that know to look for it — `"browser"` field in `package.json` is a standard thing.

The browser entrypoint is used by `webpack.config.js` to generate a suitable standalone `embark.min.js` that someone could plop into a `<script>` tag, if they wanted to use EmbarkJS in that way.

I did one thing experimentally, which also shows the utility of having a separate browser entrypoint. That is, I split out part of the testing for `this.web3` so that global/window detection only ends up in the code that's built by webpack when it goes through the browser entrypoint.  If that's not desirable, I can get rid of it and then change the browser entrypoint  to `dist/embark.js`.

