### PR TITLE
prepack -> prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build-babel": "babel --ignore 'src/browser.js' --out-dir dist src",
     "build-webpack": "npm run webpack",
     "clean": "rimraf dist embark.min.js embarkjs-*.tgz package",
-    "prepack": "npm run build",
+    "prepare": "npm run build",
     "server": "http-server",
     "test": "echo \"Error: no test specified\" && exit 1",
     "webpack": "webpack"


### PR DESCRIPTION
It's actually preferable for this package to specify a `"prepare"` script in `package.json` vs. a `"prepack"` script, since `"prepare"` allows for installing directly from git (e.g. installing from a feature branch on GitHub) despite the git repository not containing the build artifacts.

To see what I mean, create a fresh npm package:

```
mkdir -p ~/temp/tryme
cd ~/temp/tryme
npm init -y
```

Below, we'll make use of GitHub URL npm package specifiers. At present, this won't work:

```
npm install embark-framework/EmbarkJS
```

But this does work, because I changed `"prepack"` to `"prepare"` on the feature branch:

```
npm install embark-framework/EmbarkJS#features/prefer-prepare
```
