### PR TITLE
Features/fix umd for node

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,11 @@
 {
+  "comments": false,
   "compact": false,
-  "presets": [
-    ["@babel/env", {"targets": {"node": "8.11.3"}}]
-  ],
+  "ignore": ["src/browser.js"],
   "plugins": [
     "@babel/plugin-transform-runtime"
+  ],
+  "presets": [
+    ["@babel/env", {"targets": {"node": "8.11.3"}}]
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,6 @@ package
 
 embark.min.js
 embarkjs-*.tgz
-TODO
 NOTES
 npm-debug.log
+TODO

--- a/package.json
+++ b/package.json
@@ -10,12 +10,11 @@
     "src"
   ],
   "scripts": {
-    "build": "npm run clean && npm run build-babel && npm run build-webpack",
-    "build-babel": "babel --ignore 'src/browser.js' --out-dir dist src",
-    "build-webpack": "npm run webpack",
+    "babel": "babel --out-dir dist src",
+    "build": "npm run clean && npm run babel && npm run webpack",
     "clean": "rimraf dist embark.min.js embarkjs-*.tgz package",
+    "http-server": "http-server",
     "prepare": "npm run build",
-    "server": "http-server",
     "test": "echo \"Error: no test specified\" && exit 1",
     "webpack": "webpack"
   },

--- a/src/browser.js
+++ b/src/browser.js
@@ -6,7 +6,7 @@ EmbarkJS.checkWeb3 = function () {
     _EmbarkJS.checkWeb3.call(this);
     if (!this.web3 && typeof (web3) !== 'undefined') {
         this.web3 = web3;
-    } else  if (!this.web3) {
+    } else if (!this.web3) {
         this.web3 = window.web3;
     }
 };

--- a/src/embark.js
+++ b/src/embark.js
@@ -388,7 +388,7 @@ EmbarkJS.Names.register = function(name, options) {
     throw new Error('Name system provider not set; e.g EmbarkJS.Names.setProvider("ens")');
   }
   return this.currentNameSystems.register(name, options);
-}
+};
 
 EmbarkJS.Utils = {
   fromAscii: function (str) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,6 @@
 const path = require('path');
 
-const browser = {
+const standalone = {
     entry: path.resolve(__dirname, 'src') + '/browser.js',
     mode: 'production',
     module: {
@@ -25,6 +25,7 @@ const browser = {
     // },
     output: {
         filename: 'embark.min.js',
+        globalObject: 'typeof self !== \'undefined\' ? self : this',
         library: 'EmbarkJS',
         libraryTarget: 'umd',
         libraryExport: 'default',
@@ -35,5 +36,5 @@ const browser = {
 };
 
 module.exports = [
-    browser
+    standalone
 ];


### PR DESCRIPTION
Mainly, implemented a workaround in `webpack.config.js` that allows the standalone umd build (`embark.min.js`) to be `require`-able in node.js as well as usable in browsers ... otherwise it kind of defeats the purpose having a UMD build.

See:  https://github.com/webpack/webpack/issues/6522#issuecomment-371120689

Also did a little tidying up.