### PR TITLE
async package should be a dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   },
   "homepage": "https://github.com/embark-framework/EmbarkJS#readme",
   "dependencies": {
-    "@babel/runtime": "7.0.0-beta.52"
+    "@babel/runtime": "^7.0.0-beta.52",
+    "async": "^2.0.1"
   },
   "devDependencies": {
     "@babel/cli": "7.0.0-beta.52",


### PR DESCRIPTION
The async package should have an entry in `"dependencies"`.

I didn't notice previously because I was picking it up implicitly via `"devDependencies"`. I realized the problem when I tried to `require('embarkjs')` after installing via `npm i embark-framework/EmbarkJS#master`.