### PR TITLE
prep for embark usage

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,11 +1,30 @@
 {
   "comments": false,
   "compact": false,
-  "ignore": ["src/browser.js"],
+  "env": {
+    "browser": {
+      "ignore": [
+        "src/embark.js",
+        "src/node/index.js",
+        "src/standalone/index.js"
+      ],
+      "presets": [
+        ["@babel/env", {
+          "modules": false,
+          "targets": {"browsers": ["last 1 version", "not dead", "> 0.2%"]}
+        }]
+      ]
+    },
+    "node": {
+      "ignore": ["src/browser.js"],
+      "presets": [
+        ["@babel/env", {
+          "targets": {"node": "8.11.3"}
+        }]
+      ]
+    }
+  },
   "plugins": [
     "@babel/plugin-transform-runtime"
-  ],
-  "presets": [
-    ["@babel/env", {"targets": {"node": "8.11.3"}}]
   ]
 }

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
+engine-strict = true
 package-lock = false
 save-exact = true

--- a/package.json
+++ b/package.json
@@ -38,19 +38,19 @@
   },
   "homepage": "https://github.com/embark-framework/EmbarkJS#readme",
   "dependencies": {
-    "@babel/runtime": "^7.0.0-beta.52",
+    "@babel/runtime": "^7.0.0-beta.54",
     "async": "^2.0.1"
   },
   "devDependencies": {
-    "@babel/cli": "7.0.0-beta.52",
-    "@babel/core": "7.0.0-beta.52",
-    "@babel/plugin-transform-runtime": "7.0.0-beta.52",
-    "@babel/preset-env": "7.0.0-beta.52",
+    "@babel/cli": "7.0.0-beta.54",
+    "@babel/core": "7.0.0-beta.54",
+    "@babel/plugin-transform-runtime": "7.0.0-beta.54",
+    "@babel/preset-env": "7.0.0-beta.54",
     "ajv": "6.5.2",
     "babel-loader": "8.0.0-beta.4",
     "http-server": "0.11.1",
     "rimraf": "2.6.2",
-    "webpack": "4.15.1",
+    "webpack": "4.16.1",
     "webpack-cli": "3.0.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,15 +2,19 @@
   "name": "embarkjs",
   "version": "0.1.0",
   "description": "JavaScript library for easily interacting with web3 technologies",
-  "main": "./dist/index.js",
-  "browser": "./src/browser.js",
+  "main": "dist/node/index.js",
+  "browser": {
+    "./dist/node/index.js": "./dist/browser/browser.js"
+  },
   "files": [
     "dist",
     "embark.min.js",
     "src"
   ],
   "scripts": {
-    "babel": "babel --out-dir dist src",
+    "babel": "npm run babel:browser && npm run babel:node",
+    "babel:browser": "BABEL_ENV=browser babel --out-dir dist/browser src",
+    "babel:node": "BABEL_ENV=node babel --out-dir dist src",
     "build": "npm run clean && npm run babel && npm run webpack",
     "clean": "rimraf dist embark.min.js embarkjs-*.tgz package",
     "http-server": "http-server",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
   "browser": {
     "./dist/node/index.js": "./dist/browser/browser.js"
   },
+  "browserslist": [
+    "last 1 version",
+    "not dead",
+    "> 0.2%"
+  ],
   "files": [
     "dist",
     "embark.min.js",
@@ -56,5 +61,8 @@
     "rimraf": "2.6.2",
     "webpack": "4.16.1",
     "webpack-cli": "3.0.8"
+  },
+  "engines": {
+    "node" : ">=8.11.3"
   }
 }

--- a/src/browser.js
+++ b/src/browser.js
@@ -1,9 +1,11 @@
-import _EmbarkJS from './embark';
+import _EmbarkJS from './index';
 
 var EmbarkJS = Object.assign({}, _EmbarkJS);
 
+var _checkWeb3 = EmbarkJS.Contract.checkWeb3;
+
 EmbarkJS.Contract.checkWeb3 = function () {
-    _EmbarkJS.Contract.checkWeb3.call(this);
+    _checkWeb3.call(this);
     if (!this.web3 && typeof (web3) !== 'undefined') {
         this.web3 = web3;
     } else if (!this.web3) {

--- a/src/contracts.js
+++ b/src/contracts.js
@@ -1,12 +1,3 @@
-
-let isNewWeb3 = function (web3Obj) {
-  var _web3 = web3Obj || (new Web3());
-  if (typeof(_web3.version) === "string") {
-    return true;
-  }
-  return parseInt(_web3.version.api.split('.')[0], 10) >= 1;
-};
-
 let Contract = function (options) {
   var self = this;
   var i, abiElement;
@@ -17,12 +8,11 @@ let Contract = function (options) {
   this.gas = options.gas;
   this.code = '0x' + options.code;
 
-  //this.web3 = options.web3 || web3;
   this.web3 = options.web3;
 
-  this.checkWeb3.call(this);
+  Contract.checkWeb3.call(this);
 
-  if (isNewWeb3(this.web3)) {
+  if (Contract.isNewWeb3(this.web3)) {
     ContractClass = new this.web3.eth.Contract(this.abi, this.address);
     ContractClass.setProvider(this.web3.currentProvider);
     ContractClass.options.data = this.code;
@@ -176,6 +166,14 @@ let Contract = function (options) {
 };
 
 Contract.checkWeb3 = function () {};
+
+Contract.isNewWeb3 = function (web3Obj) {
+    var _web3 = web3Obj || (new Web3());
+    if (typeof(_web3.version) === "string") {
+        return true;
+    }
+    return parseInt(_web3.version.api.split('.')[0], 10) >= 1;
+};
 
 Contract.prototype.deploy = function (args, _options) {
   var self = this;

--- a/src/embark.js
+++ b/src/embark.js
@@ -1,22 +1,2 @@
-import Storage from './storage.js';
-import Names from './names.js';
-import Messages from './messages.js';
-import Contract from './contracts.js';
-import Utils from './utils.js';
-
-var EmbarkJS = {
-  onReady: function (cb) {
-    if (typeof (__embarkContext) === 'undefined') {
-      return cb();
-    }
-    return __embarkContext.execWhenReady(cb);
-  }
-};
-
-EmbarkJS.Contract = Contract;
-EmbarkJS.Storage = Storage;
-EmbarkJS.Names = Names;
-EmbarkJS.Messages = Messages;
-EmbarkJS.Utils = Utils;
-
+import EmbarkJS from './index';
 export default EmbarkJS;

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,24 @@
-module.exports = require('./embark').default;
+import Storage from './storage.js';
+import Names from './names.js';
+import Messages from './messages.js';
+import Contract from './contracts.js';
+import Utils from './utils.js';
+
+var EmbarkJS = {
+  onReady: function (cb) {
+    if (typeof (__embarkContext) === 'undefined') {
+      return cb();
+    }
+    return __embarkContext.execWhenReady(cb);
+  }
+};
+
+EmbarkJS.Contract = Contract;
+EmbarkJS.Storage = Storage;
+EmbarkJS.Names = Names;
+EmbarkJS.Messages = Messages;
+EmbarkJS.Utils = Utils;
+
+EmbarkJS.isNewWeb3 = Contract.isNewWeb3;
+
+export default EmbarkJS;

--- a/src/names.js
+++ b/src/names.js
@@ -34,6 +34,13 @@ Names.lookup = function (identifier) {
   return this.currentNameSystems.lookup(identifier);
 };
 
+Names.isAvailable = function () {
+    return this.currentNameSystems.isAvailable();
+};
+
+// To Implement
+
+
 // register a name
 Names.register = function(name, options) {
   if (!this.currentNameSystems) {

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -1,0 +1,1 @@
+module.exports = require('../embark').default;

--- a/src/standalone/index.js
+++ b/src/standalone/index.js
@@ -1,0 +1,1 @@
+module.exports = require('../../embark.min');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,28 +1,8 @@
 const path = require('path');
 
 const standalone = {
-    entry: path.resolve(__dirname, 'src') + '/browser.js',
+    entry: path.join(__dirname, 'dist/browser', 'browser.js'),
     mode: 'production',
-    module: {
-        rules: [
-            {
-                test: /\.js$/,
-                exclude: /(node_modules|bower_components)/,
-                use: {
-                    loader: 'babel-loader',
-                    options: {
-                        babelrc: false,
-                        plugins: [
-                            "@babel/plugin-transform-runtime"
-                        ],
-                        presets: [
-                            ['@babel/env']
-                        ]
-                    }
-                }
-            }
-        ]
-    },
     // optimization: {
     //     minimize: false
     // },


### PR DESCRIPTION
`isNewWeb3` helper function is expected to be on the package's default export, so that necessitates its being accessible from `contracts.js`. I made it a property on the `Contract` constructor. The only other options were duplication, or creating a circular dependency between `index.js` and `contracts.js` (which is a valid thing to do, but seemed clumsy).

The other changes mainly represent "best practices" I've been learning about with respect to babel, webpack, pkg.json fields, etc. This is (presently) a very small library, so not going for overkill; rather it makes for a good proving ground, and the lessons learned may be helpful in the upcoming pipeline/config work on Embark itself.

If/when the PR is merged, I will bump the version number and publish.