### PR TITLE
bump deps re: babel 7 release candidate 1

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,6 +8,12 @@
         "src/node/index.js",
         "src/standalone/index.js"
       ],
+      "plugins": [
+        ["@babel/plugin-transform-runtime", {
+          "corejs": 2,
+          "useESModules": true
+        }]
+      ],
       "presets": [
         ["@babel/env", {
           "modules": false,
@@ -17,14 +23,16 @@
     },
     "node": {
       "ignore": ["src/browser.js"],
+      "plugins": [
+        ["@babel/plugin-transform-runtime", {
+          "corejs": 2
+        }]
+      ],
       "presets": [
         ["@babel/env", {
           "targets": {"node": "8.11.3"}
         }]
       ]
     }
-  },
-  "plugins": [
-    "@babel/plugin-transform-runtime"
-  ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -47,14 +47,14 @@
   },
   "homepage": "https://github.com/embark-framework/EmbarkJS#readme",
   "dependencies": {
-    "@babel/runtime": "^7.0.0-beta.54",
+    "@babel/runtime-corejs2": "7.0.0-rc.1",
     "async": "^2.0.1"
   },
   "devDependencies": {
-    "@babel/cli": "7.0.0-beta.54",
-    "@babel/core": "7.0.0-beta.54",
-    "@babel/plugin-transform-runtime": "7.0.0-beta.54",
-    "@babel/preset-env": "7.0.0-beta.54",
+    "@babel/cli": "7.0.0-rc.1",
+    "@babel/core": "7.0.0-rc.1",
+    "@babel/plugin-transform-runtime": "7.0.0-rc.1",
+    "@babel/preset-env": "7.0.0-rc.1",
     "ajv": "6.5.2",
     "babel-loader": "8.0.0-beta.4",
     "cross-env": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "@babel/plugin-transform-runtime": "7.0.0-rc.1",
     "@babel/preset-env": "7.0.0-rc.1",
     "ajv": "6.5.2",
-    "babel-loader": "8.0.0-beta.4",
     "cross-env": "5.2.0",
     "http-server": "0.11.1",
     "rimraf": "2.6.2",


### PR DESCRIPTION
At the end of last week, babel `7.0.0-rc.1` was released. The rc introduces some breaking changes in the behavior of `@babel/plugin-transform-runtime`. Because the `embarkjs` package was using a caret range for its `@babel/runtime` dependency, this caused it to be effectively broken when handled by webpack in embark's pipeline.

This PR fixes it by making the needed changes relative to babel `7.0.0-rc.1`. Caret ranges have been removed, so as babel proceeds through its "rc phase" to `7.0.0` we shouldn't get more surprises.

There is a corresponding branch on embark:

https://github.com/embark-framework/embark/tree/deps_fix/babel7rc1

However, turning that branch into a PR will need to wait until this PR has been merged and we've published a new version of `embarkjs`.

I've tested that using both branches together works correctly: on Linux, macOS, and Windows.