### PR TITLE
Remove setProvider on contract

### DIFF
--- a/src/blockchain.js
+++ b/src/blockchain.js
@@ -99,7 +99,6 @@ let Contract = function (options) {
 
   if (Contract.isNewWeb3(this.web3)) {
     ContractClass = new this.web3.eth.Contract(this.abi, this.address);
-    ContractClass.setProvider(this.web3.currentProvider);
     ContractClass.options.data = this.code;
     ContractClass.options.from = this.from || this.web3.eth.defaultAccount;
     ContractClass.abi = ContractClass.options.abi;


### PR DESCRIPTION
Caused problems on tests with WS node. Also, might cause problems with the new pipeline.
Doesn't really affect functionality, because when creating a contract form `web3`, it uses its provider already and passes it.