### PR TITLE
bad reference in onReady

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import Utils from './utils.js';
 
 var EmbarkJS = {
   onReady: function (cb) {
-    if (self.Blockchain.done) {
+    if (this.Blockchain.done) {
       return cb();
     }
     this.Blockchain.finalCb = function() {


### PR DESCRIPTION
Fixed a bad reference to `self` (should be `this`) in `EmbarkJS.onReady`.