### PR TITLE
feat: allow end user to enable ethereum manually

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,9 @@ import Utils from './utils';
 var EmbarkJS = {
   onReady: function (cb) {
     Blockchain.execWhenReady(cb);
+  },
+  enableEthereum: function () {
+    return Blockchain.enableEthereum();
   }
 };
 


### PR DESCRIPTION
BREAKING CHANGE: if the developer do not call this
function, end user won't be able to make transaction

`await ethereum.enable();`

Is now extracted into the function: 
`Blockchain.enableEthereum`

https://github.com/embark-framework/embark/pull/1092

Test Scenarios:
- Access demo with direct connection
- Access demo with metamask
- Access demo with metamask already approved