### PR TITLE
fix(@embarkjs): fix unhandled promise rejection

### DIFF
--- a/src/storage.js
+++ b/src/storage.js
@@ -98,10 +98,10 @@ Storage.setProviders = async function (dappConnOptions) {
         }
       }
     }, function(err, result){
-      if(!result) throw new Error('Could not connect to a storage provider using any of the dappConnections in the storage config');
+      if(!result) console.error('Could not connect to a storage provider using any of the dappConnections in the storage config');
     });
   } catch (err) {
-    throw new Error('Failed to connect to a storage provider: ' + err.message);
+    console.error('Failed to connect to a storage provider: ' + err.message);
   }
 };
 


### PR DESCRIPTION
Previously, after EmbarkJS checked for working storage dappConnections but couldn’t find any that worked, there was an unhandled promise rejection error being logged.

The cause of this was because there was a new error being thrown inside of the `async.detectSeries` callback function (the function that executes after `detectSeries` completes). This new error was being caught by a try/catch block inside of the `detectSeries` loop.

To fix the issue, there is no new error being thrown, instead the error is logged to the console.