### PR TITLE
fix(blockchain-connect): only pass error if it didn't connect

### DIFF
--- a/src/blockchain.js
+++ b/src/blockchain.js
@@ -137,8 +137,18 @@ Blockchain.doConnect = function(connectionList, opts, doneCb) {
       } else {
         connectHttp(connectionString, next);
       }
-    }, function(_err, _connectionErr, _connected) {
+    }, function(_err, result) {
+      if (!result.connected || result.error) {
+        const connectionError = new BlockchainConnectionError(connectionErrs);
+        cb(connectionError);
+        return doneCb(connectionError);
+      }
+
       self.blockchainConnector.getAccounts((err, accounts) => {
+        if (err) {
+          cb(err);
+          return doneCb(err);
+        }
         const currentProv = self.blockchainConnector.getCurrentProvider();
         if (opts.warnAboutMetamask && currentProv && currentProv.isMetaMask) {
           // if we are using metamask, ask embark to turn on dev_funds
@@ -156,10 +166,8 @@ Blockchain.doConnect = function(connectionList, opts, doneCb) {
           self.blockchainConnector.setDefaultAccount(accounts[0]);
         }
 
-        const connectionError = new BlockchainConnectionError(connectionErrs);
-
-        cb(connectionErrs);
-        doneCb(connectionErrs);
+        cb();
+        doneCb();
       });
     });
   });

--- a/test/blockchain_test.js
+++ b/test/blockchain_test.js
@@ -41,8 +41,8 @@ describe('Blockchain', () => {
             (cb) => startRPCMockServer({successful: validServer}, cb)
           ),
           (_err, servers) => {
-            const connStrings = servers.map(server => server.connectionString);
-            Blockchain.default.connect(connStrings, {}, err => {
+            const dappConnection = servers.map(server => server.connectionString);
+            Blockchain.default.connect({dappConnection}, err => {
               if(scenario.error) assert(err);
 
               servers.forEach((server, idx) => {


### PR DESCRIPTION
Caused problems if the first connection didn't work. The second one still worked, but in the end, we still passed the error of the first one.

PS: @andremedeiros Tried to run the tests and they failed at `getAccounts`. It didn't work in master either, so not sure what's the problem.